### PR TITLE
Integrate AIDE for file integrity monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The playbook collects the following types of information:
 *   **User and Log Information:**
     *   Login history (`lastlog`)
     *   Root user's cron jobs (`crontab -l`)
+*   **File Integrity Monitoring (with AIDE - Advanced Intrusion Detection Environment):**
+    *   If enabled, initializes an AIDE baseline on the first run for a host (stored on the Ansible controller).
+    *   Subsequent runs check file integrity against this baseline.
+    *   Reports new, removed, or changed files.
 
 ## Prerequisites
 
@@ -80,6 +84,18 @@ Each playbook run creates new timestamped/dated report files.
     ansible-playbook -i <inventory_file> inventory_report.yml -e "report_dir=/custom/path/reports"
     ```
     Ensure the specified directory is writable by the user running Ansible on the control node (for Play 2 tasks). The temporary files created by Play 1 on the control node (if `report_dir` is customized for that too) also need to be writable.
+
+*   **Controlling Data Collection:** Specific data collection features can be enabled or disabled by passing variables. For example, to disable Docker and Lynis/Rkhunter/AIDE collection:
+    ```bash
+    ansible-playbook -i <inventory_file> inventory_report.yml -e "collect_docker_info=false collect_lynis_info=false collect_rkhunter_info=false collect_aide_info=false"
+    ```
+    By default, most collection features are enabled. Refer to the `vars` section in `inventory_report.yml` for available flags (e.g., `collect_services_info`, `collect_packages_info`, `collect_network_info`, `collect_user_logs_info`, `collect_system_info`, `collect_lynis_info`, `collect_rkhunter_info`, `collect_aide_info`).
+
+*   **AIDE Baseline Management:**
+    *   When AIDE collection is enabled (`collect_aide_info: true`, default), the playbook manages AIDE baselines on the Ansible controller.
+    *   On the first run for a host, AIDE is initialized on the target, and its baseline database (e.g., `inventory_hostname.db.gz`) is fetched to the `./aide_baselines/` directory (created relative to your playbook execution path).
+    *   On subsequent runs, this stored baseline is copied to the target, and `aide --check` is performed against it.
+    *   **Important:** The `./aide_baselines/` directory on your Ansible controller should be considered sensitive and managed appropriately (e.g., backed up). If you delete a host's baseline file from this directory, the playbook will re-initialize AIDE on that host during the next run. To accept current changes on a host as the new baseline, you would delete its old baseline file from `./aide_baselines/` on the controller, and let the playbook generate a new one on the next execution.
 
 ## Minimal Dependencies
 

--- a/inventory_report.yml
+++ b/inventory_report.yml
@@ -11,6 +11,9 @@
     collect_network_info: true
     collect_user_logs_info: true
     collect_system_info: true # For boot time and fs_usage
+    collect_lynis_info: true
+    collect_rkhunter_info: true
+    collect_aide_info: true
   tasks:
 
     - name: Ensure temporary report directory exists on controller
@@ -20,7 +23,16 @@
         mode: '0755'
       delegate_to: localhost
       run_once: true
-      become: true
+      become: true # Might be needed if default /tmp/reports needs root
+
+    - name: Ensure AIDE baseline directory exists on controller
+      ansible.builtin.file:
+        path: "{{ playbook_dir }}/aide_baselines"
+        state: directory
+        mode: '0755' # Controller user needs to write here
+      delegate_to: localhost
+      run_once: true
+      # No become needed if playbook_dir is user-writable
 
     - name: Gather Service Information
       tags: services
@@ -158,6 +170,160 @@
           ignore_errors: true # yaml[truthy]
       when: collect_system_info
 
+    - name: Perform Security Scans (Lynis, Rkhunter)
+      tags: security_scans
+      block:
+        - name: Ensure security scan tools are installed (lynis, rkhunter)
+          ansible.builtin.package:
+            name:
+              - lynis
+              - rkhunter
+            state: present
+          register: security_tools_install_result # We still register to potentially use details about install success/failure in status, though direct check is better
+          ignore_errors: true # yaml[truthy]
+          when: collect_lynis_info or collect_rkhunter_info
+
+        - name: Check if rkhunter is available
+          ansible.builtin.command: command -v rkhunter
+          register: rkhunter_exists
+          changed_when: false
+          ignore_errors: true # yaml[truthy]
+          when: collect_rkhunter_info
+
+        - name: Update rkhunter database (might require internet)
+          ansible.builtin.command: rkhunter --update
+          register: rkhunter_update_result
+          changed_when: "'updated' in rkhunter_update_result.stdout | lower"
+          ignore_errors: true # yaml[truthy]
+          when:
+            - collect_rkhunter_info
+            - rkhunter_exists is defined and rkhunter_exists.rc == 0
+
+        - name: Check if lynis is available
+          ansible.builtin.command: command -v lynis
+          register: lynis_exists
+          changed_when: false
+          ignore_errors: true # yaml[truthy]
+          when: collect_lynis_info
+
+        - name: Run Lynis Scan
+          ansible.builtin.command: lynis audit system --quiet --no-colors
+          register: lynis_scan_result
+          changed_when: false
+          ignore_errors: true # yaml[truthy]
+          when:
+            - collect_lynis_info
+            - lynis_exists is defined and lynis_exists.rc == 0
+
+        - name: Run Rkhunter Scan
+          ansible.builtin.command: rkhunter --check --sk --nocolors
+          register: rkhunter_scan_result
+          changed_when: false
+          ignore_errors: true # yaml[truthy]
+          when:
+            - collect_rkhunter_info
+            - rkhunter_exists is defined and rkhunter_exists.rc == 0
+      when: collect_lynis_info or collect_rkhunter_info
+
+    - name: Perform AIDE File Integrity Check
+      tags: aide
+      block:
+        - name: Install AIDE package
+          ansible.builtin.package:
+            name: aide # Common name, might need 'aide-common' or platform specific adjustments
+            state: present
+          register: aide_install_result
+          ignore_errors: true # yaml[truthy]
+
+        - name: Check if AIDE command is available
+          ansible.builtin.command: command -v aide
+          register: aide_exists
+          changed_when: false
+          ignore_errors: true # yaml[truthy]
+
+        - name: Set AIDE baseline path facts
+          ansible.builtin.set_fact:
+            aide_controller_baseline_path: "{{ playbook_dir }}/aide_baselines/{{ inventory_hostname }}.db.gz"
+            aide_target_temp_new_db_path: "/var/lib/aide/aide.db.new.gz" # Default AIDE output
+            aide_target_active_db_path: "/var/lib/aide/aide.db.gz" # Standard operational path
+          when: aide_exists.rc == 0
+
+        - name: Check if AIDE baseline exists on controller for this host
+          ansible.builtin.stat:
+            path: "{{ aide_controller_baseline_path }}"
+          delegate_to: localhost
+          register: aide_baseline_on_controller_stat
+          when: aide_exists.rc == 0
+
+        - name: Initialize AIDE and fetch baseline (if not on controller)
+          block:
+            - name: Ensure AIDE database directory exists on target
+              ansible.builtin.file:
+                path: "/var/lib/aide"
+                state: directory
+                mode: '0755' # Or more restrictive as AIDE recommends
+
+            - name: Initialize AIDE database on target
+              ansible.builtin.command: aide --init # or aideinit, depending on distro version of aide
+              register: aide_init_result
+              changed_when: false # Success (rc=0) implies the new DB is created at aide_target_temp_new_db_path
+              ignore_errors: true # yaml[truthy] (to capture status later)
+
+            - name: Rename newly initialized AIDE database
+              ansible.builtin.command: "mv {{ aide_target_temp_new_db_path }} {{ aide_target_active_db_path }}"
+              when: aide_init_result is defined and aide_init_result.rc == 0
+              register: aide_rename_result
+              changed_when: aide_rename_result.rc == 0
+              ignore_errors: true # yaml[truthy]
+
+            - name: Fetch AIDE baseline from target to controller
+              ansible.builtin.fetch:
+                src: "{{ aide_target_active_db_path }}" # e.g. /var/lib/aide/aide.db.gz
+                dest: "{{ aide_controller_baseline_path }}" # e.g. ./aide_baselines/hostname.db.gz
+                flat: yes # Ensures dest is treated as a file path
+                fail_on_missing: yes
+              when: aide_rename_result is defined and aide_rename_result.rc == 0
+              register: aide_fetch_result
+
+            - name: Set fact that baseline was initialized
+              ansible.builtin.set_fact:
+                aide_baseline_initialized_this_run: true
+              when: aide_fetch_result is defined and not aide_fetch_result.failed
+
+          when:
+            - aide_exists.rc == 0
+            - aide_baseline_on_controller_stat.stat.exists is defined and not aide_baseline_on_controller_stat.stat.exists
+            - aide_install_result is defined and not aide_install_result.failed # Ensure install didn't grossly fail
+
+        - name: Run AIDE Check (if baseline exists on controller)
+          block:
+            - name: Ensure AIDE database directory exists on target (again, for this path)
+              ansible.builtin.file:
+                path: "/var/lib/aide"
+                state: directory
+                mode: '0755'
+
+            - name: Copy AIDE baseline from controller to target
+              ansible.builtin.copy:
+                src: "{{ aide_controller_baseline_path }}"
+                dest: "{{ aide_target_active_db_path }}"
+                mode: '0600' # AIDE dbs should be protected
+              register: aide_copy_to_target_result
+
+            - name: Run AIDE check against the copied baseline
+              ansible.builtin.command: aide --check
+              register: aide_check_result
+              ignore_errors: true # AIDE exits >0 if changes are found or errors occur.
+              changed_when: false # This task only reads data.
+              when: aide_copy_to_target_result is defined and not aide_copy_to_target_result.failed
+
+          when:
+            - aide_exists.rc == 0
+            - aide_baseline_on_controller_stat.stat.exists is defined and aide_baseline_on_controller_stat.stat.exists
+            - aide_install_result is defined and not aide_install_result.failed
+
+      when: collect_aide_info
+
     - name: Set host-specific report data with sanitization
       ansible.builtin.set_fact:
         host_report_entry: >
@@ -184,7 +350,55 @@
               "cron_jobs": (root_cron.stdout_lines | default([]) if collect_user_logs_info else "Skipped"),
               "system_info_collected": "{{ collect_system_info }}",
               "boot_time": (boot_time.stdout | default('N/A') | regex_replace('\\[\\udc80-\\udcff]', '') if collect_system_info else "Skipped"),
-              "filesystem": (fs_usage.stdout_lines | default([]) if collect_system_info else "Skipped")
+              "filesystem": (fs_usage.stdout_lines | default([]) if collect_system_info else "Skipped"),
+
+              "lynis_collected": "{{ collect_lynis_info }}",
+              "lynis_status": (
+                "Skipped" if not collect_lynis_info else
+                ("Tool not found" if (lynis_exists is not defined or lynis_exists.rc != 0) else
+                  ("Scan not run" if lynis_scan_result is not defined else # Should not happen if lynis_exists.rc == 0
+                   ("Error during run" if lynis_scan_result.failed or (lynis_scan_result.rc is defined and lynis_scan_result.rc != 0) else
+                    ("Collected" if lynis_scan_result.stdout_lines | length > 0 else "No output")
+                   )
+                  )
+                )
+              ),
+              "lynis_output": (lynis_scan_result.stdout_lines | default([]) if collect_lynis_info and lynis_exists is defined and lynis_exists.rc == 0 and lynis_scan_result is defined and not lynis_scan_result.failed and lynis_scan_result.rc is defined and lynis_scan_result.rc == 0 else []),
+
+              "rkhunter_collected": "{{ collect_rkhunter_info }}",
+              "rkhunter_status": (
+                "Skipped" if not collect_rkhunter_info else
+                ("Tool not found" if (rkhunter_exists is not defined or rkhunter_exists.rc != 0) else
+                  ("Scan not run" if rkhunter_scan_result is not defined else # Should not happen if rkhunter_exists.rc == 0
+                   ("Error during run" if rkhunter_scan_result.failed or (rkhunter_scan_result.rc is defined and rkhunter_scan_result.rc != 0) else
+                    ("Collected" if rkhunter_scan_result.stdout_lines | length > 0 else "No output")
+                   )
+                  )
+                )
+              ),
+              "rkhunter_output": (rkhunter_scan_result.stdout_lines | default([]) if collect_rkhunter_info and rkhunter_exists is defined and rkhunter_exists.rc == 0 and rkhunter_scan_result is defined and not rkhunter_scan_result.failed and rkhunter_scan_result.rc is defined and rkhunter_scan_result.rc == 0 else []),
+
+              "aide_collected": "{{ collect_aide_info }}",
+              "aide_status": (
+                "Skipped" if not collect_aide_info else
+                ("Tool not found or install failed" if (aide_exists is not defined or aide_exists.rc != 0) or (aide_install_result is defined and aide_install_result.failed) else
+                  ("Baseline initialized and fetched" if aide_baseline_initialized_this_run is defined and aide_baseline_initialized_this_run else
+                    ("Baseline not found on controller (init failed or not attempted this run)" if not (aide_baseline_on_controller_stat is defined and aide_baseline_on_controller_stat.stat.exists is defined and aide_baseline_on_controller_stat.stat.exists) else
+                      ("AIDE check task did not run (e.g. baseline copy failed or AIDE command issue)" if aide_check_result is not defined else
+                        ("Error during AIDE check" if (aide_check_result.failed or aide_check_result.rc is not defined) else # .failed is true if module has critical error
+                          ("No changes found" if aide_check_result.rc == 0 else "Changes found") # Any positive RC means changes
+                        )
+                      )
+                    )
+                  )
+                )
+              ),
+              "aide_output": (
+                aide_check_result.stdout_lines | default([]) if collect_aide_info and aide_check_result is defined and aide_check_result.rc is defined else
+                (["Baseline initialized, no check performed on this run."] if aide_baseline_initialized_this_run is defined and aide_baseline_initialized_this_run else
+                  ["AIDE data not available due to previous errors or status."] # Fallback message
+                )
+              )
             }
           }
           }}

--- a/templates/enhanced_report.html.j2
+++ b/templates/enhanced_report.html.j2
@@ -439,6 +439,94 @@
         </details>
 
         <details>
+            <summary>Lynis Scan Results</summary>
+            {% if not details.lynis_collected %}
+                <p>Data collection for this section was skipped by the user.</p>
+            {% elif details.lynis_status == "Tool not found" %}
+                <p>Lynis tool not found on the host. Scan not performed.</p>
+            {% elif details.lynis_status == "Scan not run" %}
+                <p>Lynis scan did not run. Please check playbook logic or tool availability.</p>
+            {% elif details.lynis_status == "Error during run" %}
+                <p>An error occurred during the Lynis scan. Output may be incomplete or unavailable.</p>
+                {% if details.lynis_output and details.lynis_output | length > 0 %}
+                    <pre>{{ details.lynis_output | join('\n') }}</pre>
+                {% else %}
+                    <p>No specific error output captured.</p>
+                {% endif %}
+            {% elif details.lynis_status == "No output" %}
+                <p>Lynis scan ran but produced no output.</p>
+            {% elif details.lynis_status == "Collected" and details.lynis_output and details.lynis_output | length > 0 %}
+                <pre>{{ details.lynis_output | join('\n') }}</pre>
+            {% else %}
+                <p>Lynis scan data is unavailable or status is unknown: {{ details.lynis_status }}</p>
+            {% endif %}
+        </details>
+
+        <details>
+            <summary>Rkhunter Scan Results</summary>
+            {% if not details.rkhunter_collected %}
+                <p>Data collection for this section was skipped by the user.</p>
+            {% elif details.rkhunter_status == "Tool not found" %}
+                <p>Rkhunter tool not found on the host. Scan not performed.</p>
+            {% elif details.rkhunter_status == "Scan not run" %}
+                <p>Rkhunter scan did not run. Please check playbook logic or tool availability.</p>
+            {% elif details.rkhunter_status == "Error during run" %}
+                <p>An error occurred during the Rkhunter scan. Output may be incomplete or unavailable.</p>
+                {% if details.rkhunter_output and details.rkhunter_output | length > 0 %}
+                    <pre>{{ details.rkhunter_output | join('\n') }}</pre>
+                {% else %}
+                    <p>No specific error output captured.</p>
+                {% endif %}
+            {% elif details.rkhunter_status == "No output" %}
+                <p>Rkhunter scan ran but produced no output.</p>
+            {% elif details.rkhunter_status == "Collected" and details.rkhunter_output and details.rkhunter_output | length > 0 %}
+                <pre>{{ details.rkhunter_output | join('\n') }}</pre>
+            {% else %}
+                <p>Rkhunter scan data is unavailable or status is unknown: {{ details.rkhunter_status }}</p>
+            {% endif %}
+        </details>
+
+        <details>
+            <summary>AIDE File Integrity Check</summary>
+            {% if not details.aide_collected %}
+                <p>Data collection for this section was skipped by the user.</p>
+            {% elif details.aide_status == "Tool not found or install failed" %}
+                <p>AIDE tool not found on the host or installation failed. Scan not performed.</p>
+            {% elif details.aide_status == "Baseline initialized and fetched" %}
+                <p>AIDE baseline was initialized on the target and fetched to the controller. No check was performed in this run. Run the playbook again to perform a check against this new baseline.</p>
+            {% elif details.aide_status == "Baseline not found on controller (init failed or not attempted this run)" %}
+                <p>AIDE baseline for this host was not found on the controller, and initialization was not successfully completed in this run. Cannot perform check.</p>
+            {% elif details.aide_status == "AIDE check task did not run (e.g. baseline copy failed or AIDE command issue)" %}
+                <p>The AIDE check task did not run. This might be due to an issue copying the baseline to the target or an AIDE command problem.</p>
+            {% elif details.aide_status == "Error during AIDE check" %}
+                <p>An error occurred during the AIDE check. Output may be incomplete or unavailable.</p>
+                {% if details.aide_output and details.aide_output | length > 0 and "AIDE data not available" not in details.aide_output[0] %}
+                    <pre>{{ details.aide_output | join('\n') }}</pre>
+                {% else %}
+                    <p>No specific error output captured, or AIDE data was not available.</p>
+                {% endif %}
+            {% elif details.aide_status == "No changes found" %}
+                <p>AIDE check ran successfully. No file changes detected against the baseline.</p>
+                {% if details.aide_output and details.aide_output | length > 0 and "AIDE data not available" not in details.aide_output[0] %}
+                    {# AIDE might still have some summary output even with no changes #}
+                    <pre>{{ details.aide_output | join('\n') }}</pre>
+                {% endif %}
+            {% elif details.aide_status == "Changes found" %}
+                <p>AIDE check ran successfully. File changes were detected against the baseline:</p>
+                {% if details.aide_output and details.aide_output | length > 0 and "AIDE data not available" not in details.aide_output[0] %}
+                    <pre>{{ details.aide_output | join('\n') }}</pre>
+                {% else %}
+                     <p>Changes detected, but output is not available. Check raw logs if necessary.</p>
+                {% endif %}
+            {% else %}
+                <p>AIDE status is unknown or data is unavailable: {{ details.aide_status }}</p>
+                {% if details.aide_output and details.aide_output | length > 0 and "AIDE data not available" not in details.aide_output[0] %}
+                    <pre>{{ details.aide_output | join('\n') }}</pre>
+                {% endif %}
+            {% endif %}
+        </details>
+
+        <details>
             <summary>Filesystem Usage</summary>
             {% if not details.system_info_collected %}
                 <p>Data collection for this section was skipped by the user.</p>


### PR DESCRIPTION
This commit adds AIDE (Advanced Intrusion Detection Environment) capabilities to the forensic inventory playbook.

Key features:
- Installs AIDE on target hosts if `collect_aide_info` is true (default).
- Manages AIDE baselines on the Ansible controller in the `./aide_baselines/` directory, namespaced by `inventory_hostname`.
  - On the first run for a host, `aide --init` is executed on the target, and the generated database (e.g., `hostname.db.gz`) is fetched to the controller.
  - On subsequent runs, the host's baseline is copied from the controller to the target, and `aide --check` is performed.
- AIDE status and output (e.g., "Baseline initialized", "No changes found", "Changes found", errors) are included in the JSON and HTML reports.
- Users can trigger a baseline re-initialization by deleting the specific host's baseline file from the `./aide_baselines/` directory on the controller.
- README.md has been updated with documentation for this feature.

This integration significantly enhances the playbook's ability to track file system changes, a core aspect of forensic analysis and intrusion detection.